### PR TITLE
Fix `preserveColour` and `preserveAlpha` in Astro static builds

### DIFF
--- a/.changeset/gentle-kiwis-sin.md
+++ b/.changeset/gentle-kiwis-sin.md
@@ -1,0 +1,5 @@
+---
+"@sweetcorn/astro": patch
+---
+
+Fixes use of `preserveColour` and `preserveAlpha` in static builds

--- a/packages/astro/service.ts
+++ b/packages/astro/service.ts
@@ -44,7 +44,18 @@ const fitMap: Record<ImageFit, keyof FitEnum> = {
 export default {
 	// Most of these are copied from Astro’s defaults.
 	// See: https://github.com/withastro/astro/blob/8cab2a4f7ee0cfbcf0ddaec0878da637e7854b9d/packages/astro/src/assets/consts.ts#L29-L37
-	propertiesToHash: ['src', 'width', 'height', 'format', 'quality', 'fit', 'position', 'dither'],
+	propertiesToHash: [
+		'src',
+		'width',
+		'height',
+		'format',
+		'quality',
+		'fit',
+		'position',
+		'dither',
+		'preserveColour',
+		'preserveAlpha',
+	],
 
 	async getURL(options, imageConfig) {
 		let url = await defaultSharpService.getURL(options, imageConfig);


### PR DESCRIPTION
I’d forgotten to include these as relevant attributes for Astro to use to compute the hash for each image. This mean that when a static build included variants of an image with different `preserveColour` and `preserveAlpha` values, they would all be considered the same and only the first would be built.

This PR fixes that so the same image can be dithered with varying `preserve` options.