### PR TITLE
docs: fix invalid link

### DIFF
--- a/docs/src/content/docs/acknowledgements.md
+++ b/docs/src/content/docs/acknowledgements.md
@@ -20,4 +20,4 @@ Thank you to the following people, projects, and resources that made Sweetcorn p
 [dither-go]: https://github.com/makew0rld/dither
 [pigeon]: https://hbfs.wordpress.com/2013/12/31/dithering/
 [pixels]: https://www.boxentriq.com/code-breaking/pixel-values-extractor
-[dithertone]: https://www.doronsupply.com/dithertone-pro/
+[dithertone]: https://www.doronsupply.com/product/dithertone-pro/


### PR DESCRIPTION
#### Description

After clicking through the lovely documentation, I found this invalid link, which might have changed. This PR updates the link to point to the correct page again.